### PR TITLE
Fixed tags for dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 
-paramak=0.6.2
-openmc-dagmc-wrapper=0.2.2
-openmc-plasma-source=0.2.1
-cad_to_h5m=0.2.1
+paramak==0.6.2
+openmc-dagmc-wrapper==0.2.2
+openmc-plasma-source==0.2.1
+cad_to_h5m==0.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 
-paramak==0.6.2
+paramak==0.6.3
 openmc-dagmc-wrapper==0.2.2
-openmc-plasma-source==0.2.1
+openmc-plasma-source==0.2.2
 cad_to_h5m==0.2.1
+stl_to_h5m==0.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 
-paramak
-openmc-dagmc-wrapper
-openmc-plasma-source
-cad_to_h5m
+paramak=0.6.2
+openmc-dagmc-wrapper=0.2.2
+openmc-plasma-source=0.2.1
+cad_to_h5m=0.2.1


### PR DESCRIPTION
This PR adds fixed tags for dependencies.

This has the advantage of having more control over the dependencies changes + it's easier to retrigger the docker build/push workflow by simply changing the version of the dependency

@Shimwell what do you think?