### PR TITLE
added avx free option for dockerfile

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -34,11 +34,21 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ghcr.io/fusion-energy/fusion-neutronics-workflow
+          tags: ghcr.io/fusion-energy/fusion-neutronics-workflow-no-avx
           build-args: |
+            include_avx=false
             cq_version=2.1
             compile_cores=2
 
+      - name: Build and push the Docker image
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ghcr.io/fusion-energy/fusion-neutronics-workflow-avx
+          build-args: |
+            include_avx=true
+            cq_version=2.1
+            compile_cores=2
 
   upload_workflow_output_files_to_release:
     needs: build_and_push_docker_images

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,29 +109,25 @@ RUN apt-get install -y libxcb-xinerama0
 # embree from conda is not supported yet
 # conda install -c conda-forge embree >> version: 2.17.7
 # requested version "3.6.1"
-RUN if [ "$include_avx" = "false" ] ; then \
-    git clone --shallow-submodules --single-branch --branch v3.12.2 --depth 1 https://github.com/embree/embree.git && \
-    cd embree && \
-    mkdir build && \
-    cd build && \
-    cmake .. -DCMAKE_INSTALL_PREFIX=.. \
-             -DEMBREE_ISPC_SUPPORT=OFF \
-             # added following two lines to allow use on AMD CPUs see discussion
-             # https://openmc.discourse.group/t/dagmc-geometry-open-mc-aborted-unexpectedly/1369/24?u=pshriwise
-             -DEMBREE_MAX_ISA=NONE \
-             -DEMBREE_ISA_SSE42=ON && \
-    make -j"$compile_cores" && \
-    make -j"$compile_cores" install
+# added following two lines to allow use on AMD CPUs see discussion
+# https://openmc.discourse.group/t/dagmc-geometry-open-mc-aborted-unexpectedly/1369/24?u=pshriwise  
+RUN git clone --shallow-submodules --single-branch --branch v3.12.2 --depth 1 https://github.com/embree/embree.git \
+    && cd embree \
+    && mkdir build \
+    && cd build ; \
+    if [ "$include_avx" = "false" ] ; then \
+        cmake .. -DCMAKE_INSTALL_PREFIX=.. \
+                -DEMBREE_ISPC_SUPPORT=OFF \
+                -DEMBREE_MAX_ISA=NONE \
+                -DEMBREE_ISA_SSE42=ON ; \
+    fi ; \
+    if [ "$include_avx" = "true" ] ; then \
+        cmake .. -DCMAKE_INSTALL_PREFIX=.. \
+                -DEMBREE_ISPC_SUPPORT=OFF ; \
+    fi ; \
+    make -j"$compile_cores" \
+    && make -j"$compile_cores" install
 
-RUN if [ "$include_avx" = "true" ] ; then \
-    git clone --shallow-submodules --single-branch --branch v3.12.2 --depth 1 https://github.com/embree/embree.git && \
-    cd embree && \
-    mkdir build && \
-    cd build && \
-    cmake .. -DCMAKE_INSTALL_PREFIX=.. \
-             -DEMBREE_ISPC_SUPPORT=OFF && \
-    make -j"$compile_cores" && \
-    make -j"$compile_cores" install
 
 # Clone and install MOAB
 RUN mkdir MOAB && \


### PR DESCRIPTION
adds include_avx as a docker build arg so that embree can be compiled with or without avx support.

avx is not available on all cpus so this flag could help users without avx