### PR TITLE
Removing use of mat prefix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -193,7 +193,7 @@ RUN cd /opt && \
     pip install -e .[test]
 
 
-RUN conda install -c fusion-energy -c cadquery -c conda-forge paramak_develop
+RUN conda install -c fusion-energy -c cadquery -c conda-forge paramak
 
 # pip installs latest versions of analysis packages
 RUN pip install openmc-dagmc-wrapper

--- a/README.md
+++ b/README.md
@@ -93,10 +93,6 @@ Links to the packages that are utilized by the fusion-neutronics-workflow
     automated production of fusion reactor CAD models (stp and stl files) from
     parameters.
 
-    * [cad_to_h5m](https://github.com/fusion-energy/cad_to_h5m) automated
-    conversion of STP or SAT CAD files to h5m files compatible with DAGMC
-    enabled particle transport codes.
-
     * [stl_to_h5m](https://github.com/fusion-energy/stl_to_h5m) automated
     conversion of STL files to h5m files compatible with DAGMC enabled
     particle transport codes.

--- a/example_01_single_volume_cell_tally/2_run_neutronics_simulation.py
+++ b/example_01_single_volume_cell_tally/2_run_neutronics_simulation.py
@@ -10,35 +10,26 @@ from spectrum_plotter import plot_spectrum_from_tally
 
 
 # defines a simple DT neutron point source
-my_source = ops.FusionPointSource(
-    coordinate = (0,0,0),
-    temperature = 20000.,
-    fuel='DT'
-)
+my_source = ops.FusionPointSource(coordinate=(0, 0, 0), temperature=20000.0, fuel="DT")
 
 # set the geometry file to use
 geometry = odw.Geometry(
-    h5m_filename='dagmc.h5m',
+    h5m_filename="dagmc.h5m",
 )
 
 # sets the material to use
 materials = odw.Materials(
-    h5m_filename='dagmc.h5m',
-    correspondence_dict={"mat1": "eurofer"}
+    h5m_filename="dagmc.h5m", correspondence_dict={"my_material": "eurofer"}
 )
 
 # creates a cell tally for neutron flux
 tally1 = odw.CellTally(
-    tally_type="neutron_flux",
-    target="mat_my_material",
-    materials=materials
+    tally_type="neutron_flux", target="my_material", materials=materials
 )
 
 # creates a cell tally for neutron spectra
 tally2 = odw.CellTally(
-    tally_type="neutron_spectra",
-    target="mat_my_material",
-    materials=materials
+    tally_type="neutron_spectra", target="my_material", materials=materials
 )
 
 tallies = openmc.Tallies([tally1, tally2])
@@ -63,7 +54,7 @@ statepoint_file = my_model.run()
 statepoint = openmc.StatePoint(filepath=statepoint_file)
 
 # gets the first tally using its name
-my_tally_1 = statepoint.get_tally(name="mat_my_material_neutron_flux")
+my_tally_1 = statepoint.get_tally(name="my_material_neutron_flux")
 
 # gets number of neutron for a 1.3 mega joule shot
 source_strength = otuc.find_source_strength(fusion_energy_per_second_or_per_pulse=1.3e6)
@@ -78,25 +69,25 @@ result = otuc.process_tally(
 print(f"flux per second = {result}", end="\n\n")
 
 # gets the second tally using its name
-my_tally_2 = statepoint.get_tally(name="mat_my_material_neutron_spectra")
+my_tally_2 = statepoint.get_tally(name="my_material_neutron_spectra")
 
 # returns the tally converted to MeV, scaled and normalisation for source strength
 result = otuc.process_spectra_tally(
     tally=my_tally_2,
     required_units="centimeter / second",
-    required_energy_units='MeV',
-    source_strength=source_strength
+    required_energy_units="MeV",
+    source_strength=source_strength,
 )
 
 # creates a matplotlib figure of the tally
 spectrum_plot = plot_spectrum_from_tally(
-    spectrum={'neutron spectra tally': my_tally_2},
+    spectrum={"neutron spectra tally": my_tally_2},
     x_label="Energy [MeV]",
     y_label="Flux [n/cm^2s]",
     x_scale="log",
     y_scale="log",
     title="neutron spectra tally",
-    filename='my_spectrum_plot.png'
+    filename="my_spectrum_plot.png",
 )
 
-print('image saved as my_spectrum_plot.png')
+print("image saved as my_spectrum_plot.png")

--- a/example_01_single_volume_cell_tally/2_run_neutronics_simulation.py
+++ b/example_01_single_volume_cell_tally/2_run_neutronics_simulation.py
@@ -24,7 +24,7 @@ geometry = odw.Geometry(
 # sets the material to use
 materials = odw.Materials(
     h5m_filename='dagmc.h5m',
-    correspondence_dict={"mat_my_material": "eurofer"}
+    correspondence_dict={"mat1": "eurofer"}
 )
 
 # creates a cell tally for neutron flux

--- a/example_02_multi_volume_cell_tally/2_run_neutronics_simulation.py
+++ b/example_02_multi_volume_cell_tally/2_run_neutronics_simulation.py
@@ -20,14 +20,14 @@ geometry = odw.Geometry(
 materials = odw.Materials(
     h5m_filename=geometry.h5m_filename,
     correspondence_dict={
-        "mat_plasma": "DT_plasma",
-        "mat_inboard_tf_coils": "copper",
-        "mat_center_column_shield": "tungsten",
-        "mat_firstwall": "tungsten",
-        "mat_blanket": "Li4SiO4",
-        "mat_blanket_rear_wall": "eurofer",
-        "mat_divertor_upper": "tungsten",
-        "mat_divertor_lower": "tungsten",
+        "plasma": "DT_plasma",
+        "inboard_tf_coils": "copper",
+        "center_column_shield": "tungsten",
+        "firstwall": "tungsten",
+        "blanket": "Li4SiO4",
+        "blanket_rear_wall": "eurofer",
+        "divertor_upper": "tungsten",
+        "divertor_lower": "tungsten",
     }
 )
 

--- a/example_04_multi_volume_regular_mesh_tally/2_run_neutronics_simulation.py
+++ b/example_04_multi_volume_regular_mesh_tally/2_run_neutronics_simulation.py
@@ -13,13 +13,13 @@ geometry = odw.Geometry(h5m_filename='dagmc.h5m')
 # these materials are input as strings so they will be looked up in the
 # neutronics material maker package
 material_tag_to_material_dict = {
-    "mat_inboard_tf_coils": "copper",
-    "mat_center_column_shield": "tungsten",
-    "mat_firstwall": "tungsten",
-    "mat_blanket": "Li4SiO4",
-    "mat_blanket_rear_wall": "eurofer",
-    "mat_divertor_upper": "tungsten",
-    "mat_divertor_lower": "tungsten",
+    "inboard_tf_coils": "copper",
+    "center_column_shield": "tungsten",
+    "firstwall": "tungsten",
+    "blanket": "Li4SiO4",
+    "blanket_rear_wall": "eurofer",
+    "divertor_upper": "tungsten",
+    "divertor_lower": "tungsten",
 }
 
 materials = odw.Materials(


### PR DESCRIPTION
updates to stl-to-h5m and brep-to-h5m mean we no longer need the confusing mat_ prefix

I've also noticed we were using a paramak_develop conda package which can also be updated to the paramak conda package as I've moved all the functionally to the main package now :tada:  